### PR TITLE
Update questions box with fetched data

### DIFF
--- a/content.js
+++ b/content.js
@@ -176,9 +176,8 @@
     if (!state.selectedSchemas.length) { state.error = "Please select at least one context"; render(); return; }
 
     state.loading = true; state.error = null; state.currentPrompt = { status: 'pending' };
-    // Show placeholders for File Context and Questions while processing
+    // Show placeholder for File Context while processing
     state.showFileContext = true;
-    state.showQuestions = true;
     render();
     try {
       const payload = { prompt: state.originalPrompt.trim() };
@@ -550,7 +549,7 @@
           </div>` : ''}
 
 
-        ${(Array.isArray(state.questions) && state.questions.length) || (state.currentPrompt && (state.currentPrompt.status === 'pending' || state.currentPrompt.status === 'processing')) || (state.currentPrompt && state.fileContexts.length > 0 && !(state.questions && state.questions.length)) ? `
+        ${(Array.isArray(state.questions) && state.questions.length) ? `
           <div class="box" style="margin-top:12px;border-color:#fed7aa;">
             <button id="ctx-qa-toggle" class="box-body row" style="width:100%;justify-content:space-between;background:#fffbeb;border:none;outline:none;">
               <div class="row" style="gap:6px;">
@@ -561,26 +560,15 @@
             </button>
             ${state.showQuestions ? `
               <div class="box-body" style="padding-top:6px;">
-                ${state.questions && state.questions.length ? state.questions.map((q, idx) => `
+                ${state.questions.map((q, idx) => `
                   <div style="margin-bottom:8px;">
                     <label class="muted" style="display:block;margin-bottom:4px;color:#111827;">${escapeHtml(q.question)}</label>
                     <textarea class="input" data-qa-index="${idx}" rows="2" placeholder="${state.submittedAnswers && state.submittedAnswers.length ? 'Update your answer...' : 'Enter your answer...'}">${escapeHtml(q.answer || '')}</textarea>
-                  </div>`).join('') : `
-                  <div class="row" style="gap:8px;padding:8px;">
-                    <span class="loading" style="width:16px;height:16px;border:2px solid #9ca3af;border-top-color:transparent;border-radius:50%;"></span>
-                    <div class="grow">
-                      <div style="font-size:13px;color:#374151;font-weight:600;">Retrieving questions...</div>
-                      <div class="muted-sm">This may take a few moments</div>
-                    </div>
-                    <div class="status status-pending">pending</div>
-                  </div>
-                `}
-                ${state.questions && state.questions.length ? `
-                  <div class="row" style="gap:8px;">
-                    <button id="ctx-qa-submit" class="btn btn-primary grow" ${state.submittingAnswers ? 'disabled' : ''}>${state.submittingAnswers ? 'Submitting...' : (state.submittedAnswers && state.submittedAnswers.length ? 'Update' : 'Submit')}</button>
-                    <button id="ctx-qa-skip" class="btn btn-outline">${state.submittedAnswers && state.submittedAnswers.length ? 'Cancel' : 'Skip'}</button>
-                  </div>
-                ` : ''}
+                  </div>`).join('')}
+                <div class="row" style="gap:8px;">
+                  <button id="ctx-qa-submit" class="btn btn-primary grow" ${state.submittingAnswers ? 'disabled' : ''}>${state.submittingAnswers ? 'Submitting...' : (state.submittedAnswers && state.submittedAnswers.length ? 'Update' : 'Submit')}</button>
+                  <button id="ctx-qa-skip" class="btn btn-outline">${state.submittedAnswers && state.submittedAnswers.length ? 'Cancel' : 'Skip'}</button>
+                </div>
               </div>` : ''}
           </div>` : ''}
 


### PR DESCRIPTION
Display the 'Questions' box and its content only when question data is available, removing premature expansion and loading placeholders.

---
<a href="https://cursor.com/background-agent?bcId=bc-19a2e0ee-7c5f-46f1-b2b7-4fa44ef4db91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19a2e0ee-7c5f-46f1-b2b7-4fa44ef4db91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

